### PR TITLE
Use Interrupt based UART from sensor communication for serial protocol

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,10 @@ build/*
 .vscode/.browse.c_cpp.db*
 .vscode/c_cpp_properties.json
 .vscode/launch.json
+.travis.yml
+.vscode/extensions.json
+lib/readme.txt
+_autosave*
+*-bak
+*.bak
+.DS_Store

--- a/inc/comms.h
+++ b/inc/comms.h
@@ -1,7 +1,49 @@
+#pragma once
 
-#ifndef COMMS_H
-#define COMMS_H
+#define SERIAL_USART_BUFFER_SIZE 1024 // TODO: implement send_wait routine..
+typedef struct tag_serial_usart_buffer {
+    SERIAL_USART_IT_BUFFERTYPE buff[SERIAL_USART_BUFFER_SIZE];
+    int head; 
+    int tail; 
+    
+    // count of buffer overflows
+    unsigned int overflow;
+
+} SERIAL_USART_BUFFER;
+
+#if defined(SERIAL_USART2_IT) 
+
+volatile SERIAL_USART_BUFFER usart2_it_TXbuffer;
+volatile SERIAL_USART_BUFFER usart2_it_RXbuffer;
+
+int   USART2_IT_starttx();
+int   USART2_IT_send(unsigned char *data, int len);
+void  USART2_IT_IRQ(USART_TypeDef *us);
+
+#endif
+
+#if defined(SERIAL_USART3_IT) 
+
+volatile SERIAL_USART_BUFFER usart3_it_TXbuffer;
+volatile SERIAL_USART_BUFFER usart3_it_RXbuffer;
+
+int   USART3_IT_starttx();
+int   USART3_IT_send(unsigned char *data, int len);
+void  USART3_IT_IRQ(USART_TypeDef *us);
+
+#endif
+
+int                        serial_usart_buffer_count(SERIAL_USART_BUFFER *usart_buf);
+void                       serial_usart_buffer_push (SERIAL_USART_BUFFER *usart_buf, SERIAL_USART_IT_BUFFERTYPE value);
+SERIAL_USART_IT_BUFFERTYPE serial_usart_buffer_pop  (SERIAL_USART_BUFFER *usart_buf);
+
+
+
 void setScopeChannel(uint8_t ch, int16_t val);
 void consoleScope();
 void consoleLog(char *message);
-#endif
+
+/////////////////////////////////////////////////////////
+
+
+#define CLAMP(x, low, high) (((x) > (high)) ? (high) : (((x) < (low)) ? (low) : (x)))

--- a/inc/config.h
+++ b/inc/config.h
@@ -47,7 +47,6 @@
 
 //#define DEBUG_SERIAL_USART3         // right sensor board cable, disable if I2C (nunchuck or lcd) is used!
 //#define DEBUG_SERIAL_SENSOR         // send to USART3 sensor board, without framing, at the CONTROL_SENSOR_BAUD rate
-#define DEBUG_BAUD       115200     // UART baud rate
 //#define DEBUG_SERIAL_SERVOTERM
 #define DEBUG_SERIAL_ASCII          // "1:345 2:1337 3:0 4:0 5:0 6:0 7:0 8:0\r\n"
 
@@ -55,15 +54,39 @@
 
 // ###### CONTROL VIA UART (serial) ######
 //#define CONTROL_SERIAL_USART2       // left sensor board cable, disable if ADC or PPM is used!
-#define CONTROL_BAUD     19200    // control via usart from eg an Arduino or raspberry
+                                      // control via usart from eg an Arduino or raspberry
 // for Arduino, use void loop(void){ Serial.write((uint8_t *) &steer, sizeof(steer)); Serial.write((uint8_t *) &speed, sizeof(speed));delay(20); }
 
 // CONTROL_SENSOR implements control from original sensor boards.
 // the baud rate is 52177 for GD32 baseed YST boards.
 //#define READ_SENSOR
 //#define CONTROL_SENSOR
-#define CONTROL_SENSOR_BAUD     52177    // control via usart from GD32 based sensor boards @52177 baud
-//#define CONTROL_SENSOR_BAUD     26300    // reported baudrate for other sensor boards?
+
+#if defined(READ_SENSOR)
+  #define SERIAL_USART2_IT
+  #define SERIAL_USART3_IT
+  #define USART2_BAUD     52177    // control via usart from GD32 based sensor boards @52177 baud
+  #define USART3_BAUD     52177    // control via usart from GD32 based sensor boards @52177 baud
+//#define USART2_BAUD     26300    // reported baudrate for other sensor boards?
+//#define USART3_BAUD     26300    // reported baudrate for other sensor boards?
+  #define SERIAL_USART_IT_BUFFERTYPE  unsigned short
+//#define SERIAL_USART_IT_BUFFERTYPE  unsigned char // 8 bit with non original sensor boards ?
+  #define USART2_WORDLENGTH UART_WORDLENGTH_9B
+  #define USART3_WORDLENGTH UART_WORDLENGTH_9B
+//#define USART2_WORDLENGTH UART_WORDLENGTH_8B      // 8 bit with non original sensor boards ?
+//#define USART3_WORDLENGTH UART_WORDLENGTH_8B      // 8 bit with non original sensor boards ?
+
+#else
+//  #define SERIAL_USART2_IT
+  #define USART2_BAUD       115200                  // UART baud rate
+  #define USART2_WORDLENGTH UART_WORDLENGTH_8B      // UART_WORDLENGTH_8B or UART_WORDLENGTH_9B
+
+  #define SERIAL_USART3_IT
+  #define USART3_BAUD       115200                  // UART baud rate
+  #define USART3_WORDLENGTH UART_WORDLENGTH_8B      // UART_WORDLENGTH_8B or UART_WORDLENGTH_9B
+
+  #define SERIAL_USART_IT_BUFFERTYPE  unsigned char // char or short
+#endif
 
 // ###### CONTROL VIA RC REMOTE ######
 // left sensor board cable. Channel 1: steering, Channel 2: speed.
@@ -73,9 +96,9 @@
 // ###### CONTROL VIA TWO POTENTIOMETERS ######
 // ADC-calibration to cover the full poti-range: connect potis to left sensor board cable (0 to 3.3V) (do NOT use the red 15V wire in the cable!). see <How to calibrate>. turn the potis to minimum position, write value 1 to ADC1_MIN and value 2 to ADC2_MIN. turn to maximum position and repeat it for ADC?_MAX. make, flash and test it.
 //#define CONTROL_ADC                 // use ADC as input. disable DEBUG_SERIAL_USART2!
-#define ADC1_MIN 0                // min ADC1-value while poti at minimum-position (0 - 4095)
+#define ADC1_MIN 0                  // min ADC1-value while poti at minimum-position (0 - 4095)
 #define ADC1_MAX 4095               // max ADC1-value while poti at maximum-position (0 - 4095)
-#define ADC2_MIN 0                // min ADC2-value while poti at minimum-position (0 - 4095)
+#define ADC2_MIN 0                  // min ADC2-value while poti at minimum-position (0 - 4095)
 #define ADC2_MAX 4095               // max ADC2-value while poti at maximum-position (0 - 4095)
 
 // ###### CONTROL VIA NINTENDO NUNCHUCK ######
@@ -95,8 +118,8 @@
 
 // ############################### SOFTWARE SERIAL ###############################
 //
-#define SOFTWARE_SERIAL
-#define DEBUG_SOFTWARE_SERIAL
+//#define SOFTWARE_SERIAL
+//#define DEBUG_SOFTWARE_SERIAL
 // there should now be a free choice of serial GPIO pins
 #define SOFTWARE_SERIAL_RX_PIN GPIO_PIN_2    // PB10/USART3_TX Pin29      PA2/USART2_TX/ADC123_IN2  Pin16
 #define SOFTWARE_SERIAL_RX_PORT GPIOA

--- a/inc/config.h
+++ b/inc/config.h
@@ -60,8 +60,8 @@
 
 // CONTROL_SENSOR implements control from original sensor boards.
 // the baud rate is 52177 for GD32 baseed YST boards.
-#define READ_SENSOR
-#define CONTROL_SENSOR
+//#define READ_SENSOR
+//#define CONTROL_SENSOR
 #define CONTROL_SENSOR_BAUD     52177    // control via usart from GD32 based sensor boards @52177 baud
 //#define CONTROL_SENSOR_BAUD     26300    // reported baudrate for other sensor boards?
 
@@ -98,10 +98,10 @@
 #define SOFTWARE_SERIAL
 #define DEBUG_SOFTWARE_SERIAL
 // there should now be a free choice of serial GPIO pins
-#define SOFTWARE_SERIAL_RX_PIN GPIO_PIN_2
-#define SOFTWARE_SERIAL_RX_PORT GPIOB
-#define SOFTWARE_SERIAL_TX_PIN GPIO_PIN_9
-#define SOFTWARE_SERIAL_TX_PORT GPIOC
+#define SOFTWARE_SERIAL_RX_PIN GPIO_PIN_2    // PB10/USART3_TX Pin29      PA2/USART2_TX/ADC123_IN2  Pin16
+#define SOFTWARE_SERIAL_RX_PORT GPIOA
+#define SOFTWARE_SERIAL_TX_PIN GPIO_PIN_3    // PB11/USART3_RX Pin30      PA3/USART2_RX/ADC123_IN3  Pin17  
+#define SOFTWARE_SERIAL_TX_PORT GPIOA
 #define SOFTWARE_SERIAL_BAUD 9600
 
 // ############################### SERIAL PROTOCOL ###############################

--- a/inc/pid.h
+++ b/inc/pid.h
@@ -22,7 +22,7 @@
 /*-------------------------------------------------------------*/
 /*		Includes and dependencies			*/
 /*-------------------------------------------------------------*/
-#include "Tick/Tick.h"
+#include "tick/tick.h"
 #include <stdbool.h>
 #include <stdint.h>
 

--- a/inc/sensorcoms.h
+++ b/inc/sensorcoms.h
@@ -18,11 +18,6 @@
 */
 #pragma once
 
-#ifndef SENSORCOMS_H
-#define SENSORCOMS_H
-
-
-#include "stm32f1xx_hal.h"
 #include "config.h"
 
 /////////////////////////////////////////////////////////////////////////////////////
@@ -31,12 +26,11 @@
 /////////////////////////////////////////////////////////////////////////////////////
 
 
-
 #ifdef READ_SENSOR
 
 /////////////////////////////////////////////////////////
 // functions to use.
-void sensor_USART_init();
+void sensor_init();
 void sensor_read_data();
 int sensor_get_speeds(int16_t *speedL, int16_t *speedR);
 void sensor_set_flash(int side, int count);
@@ -97,7 +91,7 @@ extern SENSOR_DATA sensor_data[2];
 
 
 int  USART_sensorSend(int port, unsigned char *data, int len, int startframe);
-short USART_sensor_getrx(int port);
+SERIAL_USART_IT_BUFFERTYPE USART_sensor_getrx(int port);
 int USART_sensor_rxcount(int port);
 int USART_sensor_txcount(int port);
 /////////////////////////////////////////////////////////
@@ -105,20 +99,7 @@ int USART_sensor_txcount(int port);
 
 /////////////////////////////////////////////////////////
 // internal functions
-void USART_init_sensor_port_USART2();
-void USART_init_sensor_port_USART3();
 int  USART_sensor_starttx(int port);
-void USART_sensor_addRXshort(int port, unsigned short value);
-short USART_sensor_getTXshort(int port);
-void USART_sensor_addTXshort(int port, unsigned short value);
-
-
-/////////////////////////////////////////////////////////
-
-
-#define CLAMP(x, low, high) (((x) > (high)) ? (high) : (((x) < (low)) ? (low) : (x)))
-
-#else // end if READ_SENSOR
-#endif
+void USART_sensor_addTXshort(int port, SERIAL_USART_IT_BUFFERTYPE value);
 
 #endif

--- a/inc/setup.h
+++ b/inc/setup.h
@@ -28,3 +28,5 @@ void MX_TIM_Init(void);
 void MX_ADC1_Init(void);
 void MX_ADC2_Init(void);
 void UART_Init(void);
+void USART2_IT_init();
+void USART3_IT_init();

--- a/src/comms.c
+++ b/src/comms.c
@@ -4,11 +4,13 @@
 #include "config.h"
 #include "stdio.h"
 #include "string.h"
-#include "sensorcoms.h"
+#include "comms.h"
 #include "softwareserial.h"
 
 
 extern UART_HandleTypeDef huart2;
+extern UART_HandleTypeDef huart3;
+
 
 #ifdef DEBUG_SERIAL_USART3
 #define UART_DMA_CHANNEL DMA1_Channel2
@@ -95,6 +97,138 @@ void consoleLog(char *message)
     #if defined DEBUG_SERIAL_SENSOR && defined CONTROL_SENSOR
     USART_sensorSend(1, message, strlen(message), 0);
     #else
-    HAL_UART_Transmit_DMA(&huart2, (uint8_t *)message, strlen(message));
+      // TODO: Method to select which input is used for Protocol when both are active
+      #if defined(SERIAL_USART2_IT) && !defined(READ_SENSOR)
+        USART2_IT_send(message, strlen(message));
+      #elif defined(SERIAL_USART3_IT) && !defined(READ_SENSOR)
+        USART3_IT_send(message, strlen(message));
+      #else
+        HAL_UART_Transmit_DMA(&huart2, (uint8_t *)message, strlen(message));
+      #endif
     #endif
+}
+
+
+#ifdef SERIAL_USART2_IT  
+
+int USART2_IT_starttx() {
+    __HAL_UART_ENABLE_IT(&huart2, UART_IT_TXE);
+    return 1;
+}
+
+int USART2_IT_send(unsigned char *data, int len) {
+
+    int count = serial_usart_buffer_count(&usart2_it_TXbuffer);
+    if (count + len + 1 > SERIAL_USART_BUFFER_SIZE-3){
+        usart2_it_TXbuffer.overflow++;
+        return -1;
+    }
+
+    for (int i = 0; i < len; i++){
+        serial_usart_buffer_push(&usart2_it_TXbuffer, (SERIAL_USART_IT_BUFFERTYPE) data[i]);
+    }
+    
+    return USART2_IT_starttx();
+}
+
+//////////////////////////////////////////////////////
+// called from actual IRQ routines
+void USART2_IT_IRQ(USART_TypeDef *us) {
+  volatile uint32_t *SR     = &us->SR;  // USART Status register
+  volatile uint32_t *DR     = &us->DR;  // USART Data register
+  volatile uint32_t *CR1    = &us->CR1; // USART Control register 1
+
+  // Transmit 
+  if ((*SR) & UART_FLAG_TXE) {
+    if (serial_usart_buffer_count(&usart2_it_TXbuffer) == 0) {
+      *CR1 = (*CR1 & ~(USART_CR1_TXEIE | USART_CR1_TCIE));
+    } else {
+      *DR = (serial_usart_buffer_pop(&usart2_it_TXbuffer) & 0x1ff);    
+    }
+  }
+
+  // Receive
+  if (((*SR) & UART_FLAG_RXNE)) {
+    SERIAL_USART_IT_BUFFERTYPE rword = (*DR) & 0x01FF;
+    serial_usart_buffer_push(&usart2_it_RXbuffer, rword);
+  }
+
+  return;
+}
+
+#endif
+
+#ifdef SERIAL_USART3_IT
+
+int USART3_IT_starttx() {
+    __HAL_UART_ENABLE_IT(&huart3, UART_IT_TXE);
+    return 1;
+}
+
+int USART3_IT_send(unsigned char *data, int len) {
+
+    int count = serial_usart_buffer_count(&usart3_it_TXbuffer);
+    if (count + len + 1 > SERIAL_USART_BUFFER_SIZE-3){
+        usart3_it_TXbuffer.overflow++;
+        return -1;
+    }
+
+    for (int i = 0; i < len; i++){
+        serial_usart_buffer_push(&usart3_it_TXbuffer, (SERIAL_USART_IT_BUFFERTYPE) data[i]);
+    }
+    
+    return USART3_IT_starttx();
+}
+
+//////////////////////////////////////////////////////
+// called from actual IRQ routines
+void USART3_IT_IRQ(USART_TypeDef *us) {
+  volatile uint32_t *SR     = &us->SR;  // USART Status register
+  volatile uint32_t *DR     = &us->DR;  // USART Data register
+  volatile uint32_t *CR1    = &us->CR1; // USART Control register 1
+
+  // Transmit 
+  if ((*SR) & UART_FLAG_TXE) {
+    if (serial_usart_buffer_count(&usart3_it_TXbuffer) == 0) {
+      *CR1 = (*CR1 & ~(USART_CR1_TXEIE | USART_CR1_TCIE));
+    } else {
+      *DR = (serial_usart_buffer_pop(&usart3_it_TXbuffer) & 0x1ff);    
+    }
+  }
+
+  // Receive
+  if (((*SR) & UART_FLAG_RXNE)) {
+    SERIAL_USART_IT_BUFFERTYPE rword = (*DR) & 0x01FF;
+    serial_usart_buffer_push(&usart3_it_RXbuffer, rword);
+  }
+
+  return;
+}
+
+#endif
+
+int serial_usart_buffer_count(SERIAL_USART_BUFFER *usart_buf) {
+    int count = usart_buf->head - usart_buf->tail;
+    if (count < 0) count += SERIAL_USART_BUFFER_SIZE;
+    return count;
+}
+
+void serial_usart_buffer_push(SERIAL_USART_BUFFER *usart_buf, SERIAL_USART_IT_BUFFERTYPE value) {
+    int count = serial_usart_buffer_count(usart_buf);
+    if (count >=  SERIAL_USART_BUFFER_SIZE-2){
+        usart_buf->overflow++;
+        return;
+    }
+
+    usart_buf->buff[usart_buf->head] = value;
+    usart_buf->head = ((usart_buf->head + 1 ) % SERIAL_USART_BUFFER_SIZE);
+} 
+
+SERIAL_USART_IT_BUFFERTYPE serial_usart_buffer_pop(SERIAL_USART_BUFFER *usart_buf) {
+  SERIAL_USART_IT_BUFFERTYPE t = 0;
+  if (usart_buf->head != usart_buf->tail){
+      t = usart_buf->buff[usart_buf->tail];
+      usart_buf->tail = ((usart_buf->tail + 1 ) % SERIAL_USART_BUFFER_SIZE);
+  }
+  return t;
 }

--- a/src/flashcontent.h
+++ b/src/flashcontent.h
@@ -53,4 +53,9 @@ extern FLASH_CONTENT FlashContent;
 
 extern const FLASH_CONTENT FlashDefaults;
 
-#define FLASH_DEFAULTS { CURRENT_MAGIC,    50, 50, 0, 200,    20, 10, 0, 10,   1 }
+
+#ifdef CONTROL_SENSOR
+    #define FLASH_DEFAULTS { CURRENT_MAGIC,    50, 50, 0, 200,    20, 10, 0, 10,   1 }
+#else
+    #define FLASH_DEFAULTS { CURRENT_MAGIC,    50, 50, 0, 200,    20, 10, 0, 10,   0 }
+#endif

--- a/src/main.c
+++ b/src/main.c
@@ -404,8 +404,10 @@ int main(void) {
 
 
 
-    #ifdef READ_SENSOR
+    #if defined(INCLUDE_PROTOCOL)||defined(READ_SENSOR)
       if (!power_button_held){
+    #endif
+    #ifdef READ_SENSOR
         // read the last sensor message in the buffer
         sensor_read_data();
 
@@ -483,8 +485,14 @@ int main(void) {
           }
         } 
     #endif // end if control_sensor
- 
+    
+    #endif // READ_SENSOR
+    #if defined(INCLUDE_PROTOCOL)||defined(READ_SENSOR)
+    #ifdef READ_SENSOR
         if (!sensor_control || !FlashContent.HoverboardEnable){
+    #else
+        if (!FlashContent.HoverboardEnable){
+    #endif //READ_SENSOR
 
           if ((last_control_type != control_type) || (!enable)){
             // nasty things happen if it's not re-initialised
@@ -558,9 +566,11 @@ int main(void) {
         }
       }
 
+    #ifdef READ_SENSOR
       // send twice to make sure each side gets it.
       // if we sent diagnositc data, it seems to need this.
       sensor_send_lights();
+    #endif
     #else
 
 

--- a/src/pid.c
+++ b/src/pid.c
@@ -17,7 +17,7 @@
 	Author website: http://www.geekfactory.mx
 	Author e-mail: ruben at geekfactory dot mx
  */
-#include "PID.h"
+#include "pid.h"
 
 p_pid_controller pid_create(p_pid_controller pid, float* in, float* out, float* set, float kp, float ki, float kd)
 {

--- a/src/protocol.c
+++ b/src/protocol.c
@@ -142,6 +142,19 @@ int (*send_serial_data)( unsigned char *data, int len ) = softwareserial_Send;
 int (*send_serial_data_wait)( unsigned char *data, int len ) = softwareserial_Send_Wait;
 #endif
 
+// TODO: Method to select which output is used for Protocol when both are active
+#if defined(SERIAL_USART2_IT) && !defined(READ_SENSOR)
+extern int USART2_IT_send(unsigned char *data, int len);
+
+int (*send_serial_data)( unsigned char *data, int len ) = USART2_IT_send;
+int (*send_serial_data_wait)( unsigned char *data, int len ) = USART2_IT_send;
+#elif defined(SERIAL_USART3_IT) && !defined(READ_SENSOR)
+extern int USART3_IT_send(unsigned char *data, int len);
+
+int (*send_serial_data)( unsigned char *data, int len ) = USART3_IT_send;
+int (*send_serial_data_wait)( unsigned char *data, int len ) = USART3_IT_send;
+#endif
+
 #ifdef DEBUG_SERIAL_USART3
 // need to implement a buffering function here.
 // current DMA method needs attention...

--- a/src/stm32f1xx_it.c
+++ b/src/stm32f1xx_it.c
@@ -402,18 +402,19 @@ void EXTI15_10_IRQHandler(void)
 /////////////////////////////////////////
 // UART interrupts
 
-// used to read original sensors - calls into sensorcoms.c
-#ifdef READ_SENSOR
-// declare it here; why does it not come in with the header?
-void USART_sensor_IRQ(int port, USART_TypeDef *us);
+#if defined(SERIAL_USART2_IT)
+void USART2_IT_IRQ(USART_TypeDef *us);
 
 void USART2_IRQHandler(void){
-    USART_sensor_IRQ(0, USART2);
+    USART2_IT_IRQ(USART2);
 }
+#endif
 
+#if defined(SERIAL_USART3_IT)
+void USART3_IT_IRQ(USART_TypeDef *us);
 
 void USART3_IRQHandler(void){
-    USART_sensor_IRQ(1, USART3);
+    USART3_IT_IRQ(USART3);
 }
 #endif
 //


### PR DESCRIPTION

Separated the UART parts from the Sensor code and reused it to be used as input for the uart protocol instead of only software serial.

This is follow up to: https://github.com/btsimonh/hoverboard-firmware-hack/pull/2

My thoughts went like this: Too bad, that @btsimonh does have no motivation to implement Interrupt based UART for @EmerickH and myself. He should have lots of experience from the Sensor communication... 
Wait a minute...
So I tried to pull out the interrupt based uart part from the code and feed it into the protocol parsing. It is working, but from time to time the board crashes. (as in wheels keep on turning but not even the On/Off buttons leads to a reaction. Stopping only possible by pulling the battery).

Can somebody review the changes I made?

- [x] Review Code
- [ ] Test with Sensors
- [ ] Fix crashing bug
- [ ] clean up config.h