### PR TITLE
Littles additions to select beetween protocols

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,11 +2,8 @@ build/*
 !build/hover.hex
 .pioenvs
 .piolibdeps
-.vscode/.browse.c_cpp.db*
-.vscode/c_cpp_properties.json
-.vscode/launch.json
+.vscode/*
 .travis.yml
-.vscode/extensions.json
 lib/readme.txt
 _autosave*
 *-bak

--- a/inc/config.h
+++ b/inc/config.h
@@ -13,62 +13,6 @@
 #define CONTROL_TYPE HOVERBOARD_WITH_SOFTWARE_SERIAL_B2_C9
 //////////////////////////////////////////////////////////
 
-
-
-//////////////////////////////////////////////////////////
-// implementaiton of specific for macro control types
-// provide a short explaination here
-#if (CONTROL_TYPE == HOVERBOARD_WITH_SOFTWARE_SERIAL_B2_C9)
-  // this control type allows the board to be used AS a hoverboard,
-  // responding to sensor movements when in hoverboard mode.
-  /// and uses softwareserial for serial control on B2/C9
-  #define READ_SENSOR
-  #define CONTROL_SENSOR
-  #define SOFTWARE_SERIAL
-  #define SOFTWARE_SERIAL_RX_PIN GPIO_PIN_2
-  #define SOFTWARE_SERIAL_RX_PORT GPIOB
-  #define SOFTWARE_SERIAL_TX_PIN GPIO_PIN_9
-  #define SOFTWARE_SERIAL_TX_PORT GPIOC
-  //#define DEBUG_SERIAL_ASCII
-  #define FLASH_DEFAULT_HOVERBOARD_ENABLE 1
-#endif
-
-#if (CONTROL_TYPE == SOFTWARE_SERIAL_A2_A3)
-  // hoverboard sensor functionality is disabled
-  // and uses softwareserial for serial control on A2/A3 - 
-  // which are actually USART pins!
-  #define SOFTWARE_SERIAL
-  #define SOFTWARE_SERIAL_RX_PIN GPIO_PIN_2    // PB10/USART3_TX Pin29      PA2/USART2_TX/ADC123_IN2  Pin16
-  #define SOFTWARE_SERIAL_RX_PORT GPIOA
-  #define SOFTWARE_SERIAL_TX_PIN GPIO_PIN_3    // PB11/USART3_RX Pin30      PA3/USART2_RX/ADC123_IN3  Pin17  
-  #define SOFTWARE_SERIAL_TX_PORT GPIOA
-  //#define DEBUG_SERIAL_ASCII
-#endif
-
-
-// implementaiton of specific for macro control types
-#if (CONTROL_TYPE == USART2_CONTROLLED)
-  // hoverboard sensor functionality is disabled
-  // and control is via USART2
-  #define SERIAL_USART2_IT
-  //#define DEBUG_SERIAL_ASCII
-#endif
-
-
-// implementaiton of specific for macro control types
-#if (CONTROL_TYPE == USART3_CONTROLLED)
-  // hoverboard sensor functionality is disabled
-  // and control is via USART3
-  #define SERIAL_USART3_IT
-  //#define DEBUG_SERIAL_ASCII
-#endif
-
-// end of macro control type definitions
-//////////////////////////////////////////////////////////
-
-
-
-
 // ############################### DO-NOT-TOUCH SETTINGS ###############################
 
 #define PWM_FREQ         16000      // PWM frequency in Hz
@@ -189,9 +133,11 @@
 #define SOFTWARE_SERIAL_BAUD 9600
 
 // ############################### SERIAL PROTOCOL ###############################
-// enables processing of input characters through 'protocol.c'
-#define INCLUDE_PROTOCOL
+#define NO_PROTOCOL 0
+#define INCLUDE_PROTOCOL1 1 // enables processing of input characters through 'protocol.c'
+#define INCLUDE_PROTOCOL2 2 // enables processing of input characters through 'machine_protocol.c'
 
+#define INCLUDE_PROTOCOL INCLUDE_PROTOCOL2
 
 // ############################### DRIVING BEHAVIOR ###############################
 
@@ -224,6 +170,61 @@
 // #define FILTER              0.05
 // #define SPEED_COEFFICIENT   0.5
 // #define STEER_COEFFICIENT   -0.2
+
+//////////////////////////////////////////////////////////
+// implementaiton of specific for macro control types
+// provide a short explaination here
+#if (CONTROL_TYPE == HOVERBOARD_WITH_SOFTWARE_SERIAL_B2_C9)
+  // this control type allows the board to be used AS a hoverboard,
+  // responding to sensor movements when in hoverboard mode.
+  /// and uses softwareserial for serial control on B2/C9
+  #define READ_SENSOR
+  #define CONTROL_SENSOR
+  #define SOFTWARE_SERIAL
+  #define SOFTWARE_SERIAL_RX_PIN GPIO_PIN_2
+  #define SOFTWARE_SERIAL_RX_PORT GPIOB
+  #define SOFTWARE_SERIAL_TX_PIN GPIO_PIN_9
+  #define SOFTWARE_SERIAL_TX_PORT GPIOC
+  //#define DEBUG_SERIAL_ASCII
+  #define FLASH_DEFAULT_HOVERBOARD_ENABLE 1
+#endif
+
+#if (CONTROL_TYPE == SOFTWARE_SERIAL_A2_A3)
+  // hoverboard sensor functionality is disabled
+  // and uses softwareserial for serial control on A2/A3 - 
+  // which are actually USART pins!
+  #define SOFTWARE_SERIAL
+  #define SOFTWARE_SERIAL_RX_PIN GPIO_PIN_2    // PB10/USART3_TX Pin29      PA2/USART2_TX/ADC123_IN2  Pin16
+  #define SOFTWARE_SERIAL_RX_PORT GPIOA
+  #define SOFTWARE_SERIAL_TX_PIN GPIO_PIN_3    // PB11/USART3_RX Pin30      PA3/USART2_RX/ADC123_IN3  Pin17  
+  #define SOFTWARE_SERIAL_TX_PORT GPIOA
+  //#define DEBUG_SERIAL_ASCII
+#endif
+
+
+// implementaiton of specific for macro control types
+#if (CONTROL_TYPE == USART2_CONTROLLED)
+  // hoverboard sensor functionality is disabled
+  // and control is via USART2
+  #define SERIAL_USART2_IT
+  //#define DEBUG_SERIAL_ASCII
+#endif
+
+
+// implementaiton of specific for macro control types
+#if (CONTROL_TYPE == USART3_CONTROLLED)
+  // hoverboard sensor functionality is disabled
+  // and control is via USART3
+  #define SERIAL_USART3_IT
+  //#define DEBUG_SERIAL_ASCII
+#endif
+
+#if (INCLUDE_PROTOCOL == NO_PROTOCOL)
+  #undef INCLUDE_PROTOCOL
+#endif
+
+// end of macro control type definitions
+//////////////////////////////////////////////////////////
 
 // ############################### VALIDATE SETTINGS ###############################
 

--- a/src/main.c
+++ b/src/main.c
@@ -348,7 +348,7 @@ int main(void) {
   
   unsigned int startup_counter = 0;
 
-  #ifdef INCLUDE_PROTOCOL
+  #ifdef INCLUDE_PROTOCOL // Required in protocol 2?
   int last_control_type = CONTROL_TYPE_NONE;
   #endif
 
@@ -365,6 +365,7 @@ int main(void) {
         while (softwareserial_available() > 0){
           //if (mb_update() < 0){  // only if we're modbus idle and not our address
             short inputc = softwareserial_getrx();
+            
             protocol_byte( (unsigned char) inputc );
           //}
         }

--- a/src/protocol.c
+++ b/src/protocol.c
@@ -32,7 +32,7 @@
 #include <string.h>
 #include <stdlib.h>
 
-#ifdef INCLUDE_PROTOCOL
+#if (INCLUDE_PROTOCOL == INCLUDE_PROTOCOL1)
 
 //////////////////////////////////////////////////////////
 // two new protocols are created, and simultaneously active


### PR DESCRIPTION
I made some littles additions to select beetween protocols:
- [x] Made ability to change beetween **`INCLUDE_PROTOCOL1`** and **`INCLUDE_PROTOCOL2`** in **config.h** 
- [x] Moved macros on bottom of config to clarify
- [x] Renamed `protocol2_xxx` functions to `protocol_xxx` to make them compatible with **main.c** calls (protocol 1's `protocol_xxx` are now disabled if protocol 2 is choosen)

To fix / to do:
- [x] **`READ_SENSOR`** enabled by **`HOVERBOARD_WITH_SOFTWARE_SERIAL_B2_C9`** is activating **sensorcomms.c** file which is creating errors because it is using `usart2_it_xx` and `usart3_it_xx` variables (why?)
- [x] Missing theses functions:
     ```C
     extern void ascii_byte( unsigned char byte );
     extern void protocol_process_message(PROTOCOL_MSG2 *msg);
     ```
     Can we use the same ones as **protocol.c** ? For `ascii_byte` probably but is `protocol_process_message`=`process_message`?
- [x] Test protocol
- [x] Make a NodeJs/Python/... app to test communication

Discussion on #4 
