### PR TITLE
Add a current limit flash control, disable PMW log by default

### DIFF
--- a/inc/bldc.h
+++ b/inc/bldc.h
@@ -14,6 +14,8 @@ typedef struct tag_ELECTRICAL_PARAMS{
 
     int charging;
 
+    unsigned short dcCurLim;
+
     struct {
         float dcAmps;
         float dcAmpsAvgAcc;

--- a/inc/config.h
+++ b/inc/config.h
@@ -10,7 +10,7 @@
 #define SOFTWARE_SERIAL_A2_A3 4
 
 // thoery says this is the only thing you need to change....
-#define CONTROL_TYPE HOVERBOARD_WITH_SOFTWARE_SERIAL_B2_C9
+#define CONTROL_TYPE USART2_CONTROLLED
 //////////////////////////////////////////////////////////
 
 //////////////////////////////////////////////////////////
@@ -189,6 +189,9 @@
 //#define INCLUDE_PROTOCOL NO_PROTOCOL
 //#define INCLUDE_PROTOCOL INCLUDE_PROTOCOL1
 #define INCLUDE_PROTOCOL INCLUDE_PROTOCOL2
+
+// Log PWM value in position/speed control mode
+//define LOG_PWM
 
 // ############################### DRIVING BEHAVIOR ###############################
 

--- a/inc/config.h
+++ b/inc/config.h
@@ -10,7 +10,7 @@
 #define SOFTWARE_SERIAL_A2_A3 4
 
 // thoery says this is the only thing you need to change....
-#define CONTROL_TYPE USART2_CONTROLLED
+#define CONTROL_TYPE HOVERBOARD_WITH_SOFTWARE_SERIAL_B2_C9
 //////////////////////////////////////////////////////////
 
 //////////////////////////////////////////////////////////

--- a/src/bldc.c
+++ b/src/bldc.c
@@ -259,7 +259,7 @@ void DMA1_Channel1_IRQHandler() {
 #endif
 
   //disable PWM when current limit is reached (current chopping)
-  if(dclAmps > DC_CUR_LIMIT || timeout > TIMEOUT || enable == 0) {
+  if(dclAmps > electrical_measurements.dcCurLim || timeout > TIMEOUT || enable == 0) {
     LEFT_TIM->BDTR &= ~TIM_BDTR_MOE;
     //HAL_GPIO_WritePin(LED_PORT, LED_PIN, 1);
   } else {
@@ -267,7 +267,7 @@ void DMA1_Channel1_IRQHandler() {
     //HAL_GPIO_WritePin(LED_PORT, LED_PIN, 0);
   }
 
-  if(dcrAmps > DC_CUR_LIMIT || timeout > TIMEOUT || enable == 0) {
+  if(dcrAmps > electrical_measurements.dcCurLim || timeout > TIMEOUT || enable == 0) {
     RIGHT_TIM->BDTR &= ~TIM_BDTR_MOE;
   } else {
     RIGHT_TIM->BDTR |= TIM_BDTR_MOE;

--- a/src/flashcontent.h
+++ b/src/flashcontent.h
@@ -44,6 +44,8 @@ typedef struct tag_FLASH_CONTENT{
     unsigned short SpeedKdx100;
     unsigned short SpeedPWMIncrementLimit; // e.g. 20
 
+    unsigned short MaxCurrLim;
+
     unsigned short HoverboardEnable; // non zero to enable
     
 } FLASH_CONTENT;
@@ -57,4 +59,4 @@ extern const FLASH_CONTENT FlashDefaults;
 #define FLASH_DEFAULT_HOVERBOARD_ENABLE 0
 #endif
 
-#define FLASH_DEFAULTS { CURRENT_MAGIC,    50, 50, 0, 200,    20, 10, 0, 10,   FLASH_DEFAULT_HOVERBOARD_ENABLE }
+#define FLASH_DEFAULTS { CURRENT_MAGIC,    50, 50, 0, 200,    20, 10, 0, 10,    1500,   FLASH_DEFAULT_HOVERBOARD_ENABLE }

--- a/src/main.c
+++ b/src/main.c
@@ -309,6 +309,8 @@ int main(void) {
 
   init_PID_control();
 
+  electrical_measurements.dcCurLim = MIN(DC_CUR_LIMIT, FlashContent.MaxCurrLim / 100);
+
   for (int i = 8; i >= 0; i--) {
     buzzerFreq = i;
     HAL_Delay(100);
@@ -561,10 +563,12 @@ int main(void) {
                   //Change actuator value
                   int pwm = PositionPidFloats[i].out;
                   pwms[i] = pwm;
-                  if (i == 0){
-                    sprintf(tmp, "%d:%d\r\n", i, pwm);
-                    consoleLog(tmp);
-                  }
+                  #ifdef LOG_PWM
+                    if (i == 0){
+                      sprintf(tmp, "%d:%d\r\n", i, pwm);
+                      consoleLog(tmp);
+                    }
+                  #endif
                 }
               }
               break;
@@ -599,10 +603,12 @@ int main(void) {
                     pwms[i] = 
                       CLAMP(pwms[i] + pwm, -SpeedData.speed_max_power, SpeedData.speed_max_power);
                   }
+                  #ifdef LOG_PWM
                   if (i == 0){
                     sprintf(tmp, "%d:%d(%d) S:%d H:%d\r\n", i, pwms[i], pwm, (int)SpeedPidFloats[i].set, (int)SpeedPidFloats[i].in);
                     consoleLog(tmp);
                   }
+                  #endif
                 }
               }
               break;

--- a/src/protocol.c
+++ b/src/protocol.c
@@ -303,17 +303,17 @@ PARAMSTAT params[] = {
 
     { 0x80, "flash magic", "m", UI_SHORT, &FlashContent.magic, sizeof(short), PARAM_RW, NULL, NULL, NULL, PostWrite_writeflash },  // write this with CURRENT_MAGIC to commit to flash
 
-    { 0x82, "posn kp x 100", "pkp", UI_SHORT, &FlashContent.PositionKpx100, sizeof(short), PARAM_RW, NULL, NULL, NULL, PostWrite_PID },
-    { 0x81, "posn ki x 100", "pki", UI_SHORT, &FlashContent.PositionKix100, sizeof(short), PARAM_RW, NULL, NULL, NULL, PostWrite_PID }, // pid params for Position
+    { 0x81, "posn kp x 100", "pkp", UI_SHORT, &FlashContent.PositionKpx100, sizeof(short), PARAM_RW, NULL, NULL, NULL, PostWrite_PID },
+    { 0x82, "posn ki x 100", "pki", UI_SHORT, &FlashContent.PositionKix100, sizeof(short), PARAM_RW, NULL, NULL, NULL, PostWrite_PID }, // pid params for Position
     { 0x83, "posn kd x 100", "pkd", UI_SHORT, &FlashContent.PositionKdx100, sizeof(short), PARAM_RW, NULL, NULL, NULL, PostWrite_PID },
     { 0x84, "posn pwm lim", "pl", UI_SHORT, &FlashContent.PositionPWMLimit, sizeof(short), PARAM_RW, NULL, NULL, NULL, PostWrite_PID }, // e.g. 200
 
-    { 0x86, "speed kp x 100", "skp", UI_SHORT, &FlashContent.SpeedKpx100, sizeof(short), PARAM_RW, NULL, NULL, NULL, PostWrite_PID },
-    { 0x85, "speed ki x 100", "ski", UI_SHORT, &FlashContent.SpeedKix100, sizeof(short), PARAM_RW, NULL, NULL, NULL, PostWrite_PID }, // pid params for Speed
+    { 0x85, "speed kp x 100", "skp", UI_SHORT, &FlashContent.SpeedKpx100, sizeof(short), PARAM_RW, NULL, NULL, NULL, PostWrite_PID },
+    { 0x86, "speed ki x 100", "ski", UI_SHORT, &FlashContent.SpeedKix100, sizeof(short), PARAM_RW, NULL, NULL, NULL, PostWrite_PID }, // pid params for Speed
     { 0x87, "speed kd x 100", "skd", UI_SHORT, &FlashContent.SpeedKdx100, sizeof(short), PARAM_RW, NULL, NULL, NULL, PostWrite_PID },
     { 0x88, "speed pwm incr lim", "sl", UI_SHORT, &FlashContent.SpeedPWMIncrementLimit, sizeof(short), PARAM_RW, NULL, NULL, NULL, PostWrite_PID }, // e.g. 20
 
-    { 0x89, "max current limit x 100", "cl", UI_SHORT, &FlashContent.MaxCurrLim, sizeof(short), PARAM_RW, NULL, NULL, NULL, PostWrite_PID }, // by default 1500 (=15 amps), limited by DC_CUR_LIMIT
+    { 0x89, "max current limit x 100", "cl", UI_SHORT, &FlashContent.MaxCurrLim, sizeof(short), PARAM_RW, NULL, NULL, NULL, PostWrite_Cur_Limit }, // by default 1500 (=15 amps), limited by DC_CUR_LIMIT
 
     { 0xA0, "hoverboard enable", "he", UI_SHORT, &FlashContent.HoverboardEnable, sizeof(short), PARAM_RW, NULL, NULL, NULL, NULL } // e.g. 20
 };

--- a/src/protocol.c
+++ b/src/protocol.c
@@ -118,6 +118,8 @@ extern uint8_t buzzerPattern; // global variable for the buzzer pattern. can be 
 extern int buzzerLen;
 extern uint8_t enablescope; // enable scope on values
 
+extern volatile ELECTRICAL_PARAMS electrical_measurements;
+
 ///////////////////////////////////////////////
 
 
@@ -269,6 +271,10 @@ void PostWrite_PID(){
     change_PID_constants();
 }
 
+void PostWrite_Cur_Limit(){
+    electrical_measurements.dcCurLim = MIN(DC_CUR_LIMIT, FlashContent.MaxCurrLim / 100);
+}
+
 
 static int version = 1;
 
@@ -306,6 +312,8 @@ PARAMSTAT params[] = {
     { 0x85, "speed ki x 100", "ski", UI_SHORT, &FlashContent.SpeedKix100, sizeof(short), PARAM_RW, NULL, NULL, NULL, PostWrite_PID }, // pid params for Speed
     { 0x87, "speed kd x 100", "skd", UI_SHORT, &FlashContent.SpeedKdx100, sizeof(short), PARAM_RW, NULL, NULL, NULL, PostWrite_PID },
     { 0x88, "speed pwm incr lim", "sl", UI_SHORT, &FlashContent.SpeedPWMIncrementLimit, sizeof(short), PARAM_RW, NULL, NULL, NULL, PostWrite_PID }, // e.g. 20
+
+    { 0x89, "max current limit x 100", "cl", UI_SHORT, &FlashContent.MaxCurrLim, sizeof(short), PARAM_RW, NULL, NULL, NULL, PostWrite_PID }, // by default 1500 (=15 amps), limited by DC_CUR_LIMIT
 
     { 0xA0, "hoverboard enable", "he", UI_SHORT, &FlashContent.HoverboardEnable, sizeof(short), PARAM_RW, NULL, NULL, NULL, NULL } // e.g. 20
 };


### PR DESCRIPTION
- Added a flash `max current limit x 100` variable, replacing actual **DC_CUR_LIMIT**
  Value will be always < DC_CUR_LIMIT for security
- Added a **LOG_PWM** option to speed up main loop when not debugging.

**TODO:**
- [x] I changed `#define CONTROL_TYPE USART2_CONTROLLED`, maybe I should come back to default **HOVERBOARD_WITH_SOFTWARE_SERIAL_B2_C9**
- [x] Test!
- [x] ~~Remove buzzer~~ -> It's only on the total current limit so if <15 A/motor, no beep

### Fully working!