### PR TITLE
custom commands (buzzer and lightweight speed/steer)

### DIFF
--- a/inc/bldc.h
+++ b/inc/bldc.h
@@ -14,7 +14,7 @@ typedef struct tag_ELECTRICAL_PARAMS{
 
     int charging;
 
-    unsigned short dcCurLim;
+    float dcCurLim;
 
     struct {
         float dcAmps;

--- a/inc/protocol.h
+++ b/inc/protocol.h
@@ -16,10 +16,10 @@
 * You should have received a copy of the GNU General Public License
 * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-#ifndef PROCOTOL_H
-#define PROCOTOL_H
+#pragma once
 
 #include "config.h"
+#include <stdint.h>
 
 
 
@@ -112,7 +112,7 @@ typedef struct tag_PROTOCOL_LEN_ONWARDS {
 // content of 'bytes' above, for single byte commands
 typedef struct tag_PROTOCOL_BYTES {
     unsigned char cmd; //
-    unsigned char bytes[253];
+    unsigned char bytes[252];
 } PROTOCOL_BYTES;
 
 
@@ -191,6 +191,5 @@ typedef struct tag_POSN_INCR {
     long Right;
 } POSN_INCR;
 
-#endif
 
 #endif

--- a/inc/protocol.h
+++ b/inc/protocol.h
@@ -67,6 +67,27 @@ typedef struct tag_SPEED_DATA {
 
 extern SPEED_DATA SpeedData;
 
+
+typedef struct {
+    uint8_t buzzerFreq;
+    uint8_t buzzerPattern;
+    uint16_t buzzerLen;
+} BUZZER;
+
+extern BUZZER Buzzer;
+
+
+typedef struct {
+    // both of these values are absolute values ranging from -1000 to 1000
+    // base_pwm plus/minus steer is the raw PWM value
+    // wether steer is added or substracted depends on the side R/L
+    int16_t base_pwm;
+    int16_t steer;
+} PWM_STEER_CMD;
+
+extern PWM_STEER_CMD PwmSteerCmd;
+
+
 extern int control_type;
 #define CONTROL_TYPE_NONE 0
 #define CONTROL_TYPE_POSITION 1

--- a/src/ascii_protocol.c
+++ b/src/ascii_protocol.c
@@ -77,7 +77,7 @@ extern uint8_t disablepoweroff;
 extern int powerofftimer;
 extern uint8_t buzzerFreq;    // global variable for the buzzer pitch. can be 1, 2, 3, 4, 5, 6, 7...
 extern uint8_t buzzerPattern; // global variable for the buzzer pattern. can be 1, 2, 3, 4, 5, 6, 7...
-extern int buzzerLen;
+extern uint16_t buzzerLen;
 extern uint8_t enablescope; // enable scope on values
 
 static int speedB = 0;

--- a/src/ascii_protocol.c
+++ b/src/ascii_protocol.c
@@ -203,7 +203,7 @@ int ascii_process_immediate(unsigned char byte){
         case 'W':
         case 'w':
             processed = 1;
-            if (!enable) { speedB = 0; steerB = 0; }
+            if (!enable) { speedB = 0; steerB = 0; PwmSteerCmd.base_pwm = 0; PwmSteerCmd.steer = 0; }
             enable = 1;
             timeout = 0;
 
@@ -216,6 +216,7 @@ int ascii_process_immediate(unsigned char byte){
                 case CONTROL_TYPE_SPEED:
                 case CONTROL_TYPE_PWM:
                     speedB += 10*dir;
+                    PwmSteerCmd.base_pwm += 10*dir;
                     SpeedData.wanted_speed_mm_per_sec[1] = CLAMP(speedB * SPEED_COEFFICIENT -  steerB * STEER_COEFFICIENT, -1000, 1000);
                     SpeedData.wanted_speed_mm_per_sec[0] = CLAMP(speedB * SPEED_COEFFICIENT +  steerB * STEER_COEFFICIENT, -1000, 1000);
                     sprintf(ascii_out, "speed now %d, steer now %d, speedL %ld, speedR %ld\r\n", speedB, steerB, SpeedData.wanted_speed_mm_per_sec[0], SpeedData.wanted_speed_mm_per_sec[1]);
@@ -229,7 +230,7 @@ int ascii_process_immediate(unsigned char byte){
         case 'D':
         case 'd':
             processed = 1;
-            if (!enable) { speedB = 0; steerB = 0; }
+            if (!enable) { speedB = 0; steerB = 0; PwmSteerCmd.base_pwm = 0; PwmSteerCmd.steer = 0; }
             enable = 1;
             timeout = 0;
             switch (control_type){
@@ -241,6 +242,7 @@ int ascii_process_immediate(unsigned char byte){
                 case CONTROL_TYPE_SPEED:
                 case CONTROL_TYPE_PWM:
                     steerB += 10*dir;
+                    PwmSteerCmd.steer += 10*dir;
                     SpeedData.wanted_speed_mm_per_sec[1] = CLAMP(speedB * SPEED_COEFFICIENT -  steerB * STEER_COEFFICIENT, -1000, 1000);
                     SpeedData.wanted_speed_mm_per_sec[0] = CLAMP(speedB * SPEED_COEFFICIENT +  steerB * STEER_COEFFICIENT, -1000, 1000);
                     sprintf(ascii_out, "speed now %d, steer now %d, speedL %ld, speedR %ld\r\n", speedB, steerB, SpeedData.wanted_speed_mm_per_sec[0], SpeedData.wanted_speed_mm_per_sec[1]);
@@ -253,6 +255,8 @@ int ascii_process_immediate(unsigned char byte){
             processed = 1;
             speedB = 0; 
             steerB = 0;
+            PwmSteerCmd.base_pwm = 0;
+            PwmSteerCmd.steer = 0;
             SpeedData.wanted_speed_mm_per_sec[0] = SpeedData.wanted_speed_mm_per_sec[1] = speedB;
             HallData[0].HallSpeed_mm_per_s = HallData[1].HallSpeed_mm_per_s = 0;
             dspeeds[0] = dspeeds[1] = speedB;
@@ -272,6 +276,8 @@ int ascii_process_immediate(unsigned char byte){
             enable_immediate = 0;
             speedB = 0; 
             steerB = 0;
+            PwmSteerCmd.base_pwm = 0;
+            PwmSteerCmd.steer = 0;
             SpeedData.wanted_speed_mm_per_sec[0] = SpeedData.wanted_speed_mm_per_sec[1] = speedB;
             HallData[0].HallSpeed_mm_per_s = HallData[1].HallSpeed_mm_per_s = 0;
             dspeeds[0] = dspeeds[1] = speedB;
@@ -606,6 +612,8 @@ void ascii_process_msg(char *cmd, int len){
         case 'i':
             speedB = 0; 
             steerB = 0;
+            PwmSteerCmd.base_pwm = 0;
+            PwmSteerCmd.steer = 0;
             SpeedData.wanted_speed_mm_per_sec[0] = SpeedData.wanted_speed_mm_per_sec[1] = speedB;
             dspeeds[0] = dspeeds[1] = speedB;
             PosnData.wanted_posn_mm[0] = HallData[0].HallPosn_mm;

--- a/src/main.c
+++ b/src/main.c
@@ -241,7 +241,6 @@ void init_flash_content(){
 
 
 int main(void) {
-  char tmp[200];
   HAL_Init();
   __HAL_RCC_AFIO_CLK_ENABLE();
   HAL_NVIC_SetPriorityGrouping(NVIC_PRIORITYGROUP_4);


### PR DESCRIPTION
added functionality to control Buzzer via protocol and a speed/steer control method which does not have all the overhead like SpeedData.

I don't remember if we agreed to a numbering scheme - I just picked some. Feel free to change.